### PR TITLE
Add minimal WordPress theme with Tailwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# prototype
+# Prototype Repository
+
+This repository contains a minimal WordPress theme built with Gutenberg blocks and Tailwind CSS. See `guten-tailwind-theme/` for the theme files and setup instructions.

--- a/guten-tailwind-theme/.gitignore
+++ b/guten-tailwind-theme/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/style.css

--- a/guten-tailwind-theme/README.md
+++ b/guten-tailwind-theme/README.md
@@ -1,0 +1,20 @@
+# Guten Tailwind Theme
+
+This minimal WordPress theme is built for the block editor (Gutenberg) and uses Tailwind CSS for styling. No core block patterns are registered.
+
+## Setup
+
+1. Install Node dependencies:
+   ```bash
+   npm install
+   ```
+2. Build the CSS:
+   ```bash
+   npm run build
+   ```
+   Use `npm run watch` during development to rebuild on changes.
+3. Copy the theme folder into `wp-content/themes/` of your WordPress installation and activate it.
+
+## Tailwind configuration
+
+Tailwind scans PHP templates in this theme to generate the final CSS. Adjust `tailwind.config.js` if you add custom template folders.

--- a/guten-tailwind-theme/functions.php
+++ b/guten-tailwind-theme/functions.php
@@ -1,0 +1,11 @@
+<?php
+function guten_tailwind_setup() {
+    add_theme_support('title-tag');
+    remove_theme_support('core-block-patterns');
+}
+add_action('after_setup_theme', 'guten_tailwind_setup');
+
+function guten_tailwind_enqueue_scripts() {
+    wp_enqueue_style('guten-tailwind-style', get_template_directory_uri() . '/dist/style.css', [], null);
+}
+add_action('wp_enqueue_scripts', 'guten_tailwind_enqueue_scripts');

--- a/guten-tailwind-theme/index.php
+++ b/guten-tailwind-theme/index.php
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo('charset'); ?>" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+    <main class="container mx-auto py-8">
+        <?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
+            <?php the_content(); ?>
+        <?php endwhile; else : ?>
+            <p><?php esc_html_e('No posts found.', 'guten-tailwind'); ?></p>
+        <?php endif; ?>
+    </main>
+    <?php wp_footer(); ?>
+</body>
+</html>

--- a/guten-tailwind-theme/package.json
+++ b/guten-tailwind-theme/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "guten-tailwind-theme",
+  "version": "1.0.0",
+  "private": true,
+  "devDependencies": {
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.0.0"
+  },
+  "scripts": {
+    "build": "tailwindcss -i ./src/styles.css -o ./dist/style.css --minify",
+    "watch": "tailwindcss -i ./src/styles.css -o ./dist/style.css --watch"
+  }
+}

--- a/guten-tailwind-theme/postcss.config.js
+++ b/guten-tailwind-theme/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/guten-tailwind-theme/src/styles.css
+++ b/guten-tailwind-theme/src/styles.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/guten-tailwind-theme/style.css
+++ b/guten-tailwind-theme/style.css
@@ -1,0 +1,6 @@
+/*
+Theme Name: Guten Tailwind Theme
+Author: Example
+Description: Minimal WordPress theme using Gutenberg blocks and Tailwind CSS.
+Version: 0.1
+*/

--- a/guten-tailwind-theme/tailwind.config.js
+++ b/guten-tailwind-theme/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    "./*.php",
+    "./template-parts/**/*.php"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/guten-tailwind-theme/theme.json
+++ b/guten-tailwind-theme/theme.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+  "settings": {
+    "appearanceTools": true
+  },
+  "styles": {}
+}


### PR DESCRIPTION
## Summary
- add a minimal WordPress theme using Gutenberg and Tailwind CSS
- document usage in root README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688395fa2f60832c8aadeb88c386893f